### PR TITLE
Add language-specific alphabets for letter buttons

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -353,7 +353,7 @@ viewGameScreen model =
             [ h1 (applyStyles maskedWordStyles) [ text (formatMaskedWord (getMaskedWord model.currentWord model.guessedLetters)) ]
             ]
         , div (applyStyles letterButtonsContainerStyles)
-            (viewLetterButtons model.currentWord model.guessedLetters model.gameState)
+            (viewLetterButtons (Maybe.withDefault English model.selectedLanguage) model.currentWord model.guessedLetters model.gameState)
         , viewErrorMessage model.uiLanguage model.errorMessage
         ]
 
@@ -723,10 +723,10 @@ clearErrorButtonStyles =
 letterButtonsContainerStyles : List (String, String)
 letterButtonsContainerStyles = 
     [ ("display", "grid")
-    , ("grid-template-columns", "repeat(auto-fit, minmax(40px, 1fr))")
-    , ("gap", "8px")
+    , ("grid-template-columns", "repeat(auto-fill, minmax(38px, 1fr))")
+    , ("gap", "6px")
     , ("margin", "20px 0")
-    , ("padding", "15px")
+    , ("padding", "12px")
     , ("background", "#f8f9fa")
     , ("border-radius", "8px")
     , ("border", "1px solid #e9ecef")
@@ -740,13 +740,13 @@ letterButtonStyles =
     , ("color", "#333")
     , ("border", "2px solid #ddd")
     , ("border-radius", "6px")
-    , ("padding", "8px")
-    , ("font-size", "1rem")
+    , ("padding", "6px")
+    , ("font-size", "0.95rem")
     , ("font-weight", "600")
     , ("cursor", "pointer")
     , ("transition", "all 0.2s ease")
-    , ("min-width", "40px")
-    , ("min-height", "40px")
+    , ("min-width", "38px")
+    , ("min-height", "38px")
     , ("display", "flex")
     , ("align-items", "center")
     , ("justify-content", "center")
@@ -843,11 +843,25 @@ validateGuess input guessedLetters =
     validateUserInput input guessedLetters
 
 
+-- Get alphabet for specific language
+getAlphabetForLanguage : Language -> String
+getAlphabetForLanguage language =
+    case language of
+        English ->
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        
+        German ->
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÜß"
+        
+        Estonian ->
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÜÕŠŽ"
+
+
 -- Generate letter buttons for the alphabet
-viewLetterButtons : String -> List Char -> GameState -> List (Html Msg)
-viewLetterButtons currentWord guessedLetters gameState =
+viewLetterButtons : Language -> String -> List Char -> GameState -> List (Html Msg)
+viewLetterButtons language currentWord guessedLetters gameState =
     let
-        alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        alphabet = getAlphabetForLanguage language
             |> String.toList
         
         makeButton : Char -> Html Msg


### PR DESCRIPTION
## Summary
- Adds language-specific alphabets for the letter button interface
- Players can now guess words containing special characters in German and Estonian

## Changes
- **English**: Standard A-Z alphabet (26 letters)
- **German**: A-Z plus Ä, Ö, Ü, ß (30 letters total)
- **Estonian**: A-Z plus Ä, Ö, Ü, Õ, Š, Ž (32 letters total)

## Technical Details
- Added `getAlphabetForLanguage` function that returns the appropriate alphabet string for each language
- Updated `viewLetterButtons` to accept a language parameter and use the correct alphabet
- Adjusted button grid layout to accommodate extra letters with slightly smaller buttons (38px) and tighter spacing
- The letter buttons dynamically show the correct alphabet based on the selected game language

## Test Plan
- [x] All 69 tests pass
- [x] Build completes successfully
- [x] English shows 26 letter buttons
- [x] German shows 30 letter buttons including umlauts and ß
- [x] Estonian shows 32 letter buttons including special characters

🤖 Generated with Claude Code