### PR TITLE
Fix Play Again button to preserve user selections

### DIFF
--- a/tests/UpdateTest.elm
+++ b/tests/UpdateTest.elm
@@ -296,7 +296,7 @@ suite =
                         updatedModel
             ]
         , describe "PlayAgain message"
-            [ test "resets game state and transitions to DifficultySelection" <|
+            [ test "falls back to BackToStart when selections are missing" <|
                 \_ ->
                     let
                         gameOverModel = 
@@ -311,7 +311,7 @@ suite =
                         updatedModel = updateModel PlayAgain gameOverModel
                     in
                     Expect.all
-                        [ \m -> Expect.equal m.currentScreen LanguageSelection
+                        [ \m -> Expect.equal m.currentScreen Start
                         , \m -> Expect.equal m.currentWord ""
                         , \m -> Expect.equal m.guessedLetters []
                         , \m -> Expect.equal m.remainingGuesses maxGuesses
@@ -321,6 +321,35 @@ suite =
                         , \m -> Expect.equal m.selectedDifficulty Nothing
                         , \m -> Expect.equal m.selectedLanguage Nothing
                         , \m -> Expect.equal m.selectedCategory Nothing
+                        ]
+                        updatedModel
+            
+            , test "preserves selections when all selections are present" <|
+                \_ ->
+                    let
+                        gameOverModel = 
+                            { initialModel 
+                            | currentScreen = GameOver
+                            , currentWord = "cat"
+                            , guessedLetters = ['c', 'a', 't']
+                            , remainingGuesses = 3
+                            , gameState = Won
+                            , selectedLanguage = Just English
+                            , selectedCategory = Just Animals
+                            , selectedDifficulty = Just Easy
+                            }
+                        updatedModel = updateModel PlayAgain gameOverModel
+                    in
+                    Expect.all
+                        [ \m -> Expect.equal m.currentWord ""
+                        , \m -> Expect.equal m.guessedLetters []
+                        , \m -> Expect.equal m.remainingGuesses maxGuesses
+                        , \m -> Expect.equal m.gameState Playing
+                        , \m -> Expect.equal m.userInput ""
+                        , \m -> Expect.equal m.errorMessage Nothing
+                        , \m -> Expect.equal m.selectedDifficulty (Just Easy)
+                        , \m -> Expect.equal m.selectedLanguage (Just English)
+                        , \m -> Expect.equal m.selectedCategory (Just Animals)
                         ]
                         updatedModel
             ]


### PR DESCRIPTION
## Summary
- Fix Play Again button to preserve language, category, and difficulty selections
- Play Again now immediately starts a new game with the same settings
- Back to Start still provides full reset functionality
- Updated tests to cover both behaviors

## Changes Made
- Modified `handlePlayAgain` in `src/Main.elm` to preserve user selections
- Added logic to generate new word immediately with existing settings
- Updated `UpdateTest.elm` with proper test coverage for both scenarios
- Play Again falls back to Back to Start behavior when selections are missing

## Test Coverage
- Added test for fallback behavior when selections are missing
- Added test for preserving selections when all are present
- All 70 tests passing

## User Experience Improvement
Before: Both buttons did the same thing (reset everything)
After: 
- **Play Again**: Quick restart with same settings
- **Back to Start**: Full reset to beginning

🤖 Generated with [Claude Code](https://claude.ai/code)